### PR TITLE
🔀 Add node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+node_modules


### PR DESCRIPTION
This is done to improve cloning times and is also common practice